### PR TITLE
Add Build & Push to GCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # ratchet:actions/attest-build-provenance@v2
         with:
-          subject-name: ghcr.io/${{ github.repository }}
+          subject-name: gcr.io/polaris-449516/polaris/polaris
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 


### PR DESCRIPTION
As we're only going to host Polaris on GCP, I'm pushing the image directly into GCR instead of going via GHCR.

The workflow to deploy isn't included yet because the Cloud Run instance doesn't yet exist.